### PR TITLE
[FIX] NameError in health_check endpoint 수정

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,8 +30,8 @@ async def root():
 @app.get("/health")
 async def health_check():
     """헬스체크 엔드포인트"""
-    # 의도적인 버그: 정의되지 않은 변수 참조
-    server_status = undefined_variable  # NameError 발생
+    # 버그 수정: undefined_variable 제거하고 적절한 값으로 대체
+    server_status = "running"  # 정상적인 서버 상태 값
     return {"status": "healthy", "server": server_status}
 
 


### PR DESCRIPTION
## 🐛 버그 수정

### 문제
- `/health` 엔드포인트에서 정의되지 않은 변수 `undefined_variable`을 참조하여 `NameError` 발생
- 헬스체크 기능이 정상적으로 작동하지 않음

### 해결
- `undefined_variable`을 제거하고 적절한 값 `"running"`으로 대체
- 헬스체크 엔드포인트가 정상적으로 응답하도록 수정

### 변경사항
- `backend/app/main.py` 파일의 `health_check()` 함수 수정
- `server_status` 변수에 고정값 `"running"` 할당

### 테스트
- 수정 후 `/health` 엔드포인트 정상 동작 확인

Fixes #[이슈번호]